### PR TITLE
Tween/Sequence overflows; no time drift

### DIFF
--- a/gween.go
+++ b/gween.go
@@ -14,12 +14,13 @@ type (
 		begin    float32
 		end      float32
 		change   float32
+		Overflow float32
 		easing   ease.TweenFunc
 	}
 )
 
-// New will return a new Tween when passed a begining and end value, the duration
-// of the tween and the easing function to anumate between the two values. The
+// New will return a new Tween when passed a beginning and end value, the duration
+// of the tween and the easing function to animate between the two values. The
 // easing function can be one of the provided easing functions from the ease package
 // or you can provide one of your own.
 func New(begin, end, duration float32, easing ease.TweenFunc) *Tween {
@@ -29,16 +30,19 @@ func New(begin, end, duration float32, easing ease.TweenFunc) *Tween {
 		change:   end - begin,
 		duration: duration,
 		easing:   easing,
+		Overflow: 0,
 	}
 }
 
 // Set will set the current time along the duration of the tween. It will then return
 // the current value as well as a boolean to determine if the tween is finished.
 func (tween *Tween) Set(time float32) (current float32, isFinished bool) {
+	tween.Overflow = 0
 	if time <= 0 {
 		tween.time = 0
 		current = tween.begin
 	} else if time >= tween.duration {
+		tween.Overflow = time - tween.duration
 		tween.time = tween.duration
 		current = tween.end
 	} else {

--- a/gween_test.go
+++ b/gween_test.go
@@ -15,16 +15,30 @@ func TestNew(t *testing.T) {
 	assert.Equal(t, float32(10), tween.end)
 	assert.Equal(t, float32(10), tween.change)
 	assert.Equal(t, float32(10), tween.duration)
+	assert.Equal(t, float32(0), tween.time)
+	assert.Equal(t, float32(0), tween.Overflow)
 }
 
 func TestTween_Set(t *testing.T) {
 	tween := New(0, 10, 10, ease.Linear)
 	current, isFinished := tween.Set(2)
 	assert.Equal(t, float32(2), current)
+	assert.Equal(t, float32(0), tween.Overflow)
 	assert.False(t, isFinished)
 	current, isFinished = tween.Set(11)
 	assert.Equal(t, float32(10), current)
+	assert.Equal(t, float32(1), tween.Overflow)
 	assert.True(t, isFinished)
+}
+
+func TestTween_SetNeg(t *testing.T) {
+	tween := New(0, 10, 10, ease.Linear)
+	current, isFinished := tween.Set(2)
+	assert.Equal(t, float32(2), current)
+	assert.False(t, isFinished)
+	current, isFinished = tween.Set(-1)
+	assert.Equal(t, float32(0), current)
+	assert.False(t, isFinished)
 }
 
 func TestTween_Reset(t *testing.T) {
@@ -32,58 +46,37 @@ func TestTween_Reset(t *testing.T) {
 	current, isFinished := tween.Set(2)
 	assert.Equal(t, float32(2), current)
 	assert.Equal(t, float32(2), tween.time)
+	assert.Equal(t, float32(0), tween.Overflow)
 	assert.False(t, isFinished)
 	tween.Reset()
 	assert.Equal(t, float32(0), tween.time)
+	assert.Equal(t, float32(0), tween.Overflow)
 }
 
 func TestTween_Update(t *testing.T) {
 	tween := New(0, 10, 10, ease.Linear)
 	current, isFinished := tween.Update(2)
 	assert.Equal(t, float32(2), current)
+	assert.Equal(t, float32(0), tween.Overflow)
 	assert.False(t, isFinished)
 	current, isFinished = tween.Update(9)
 	assert.Equal(t, float32(10), current)
+	assert.Equal(t, float32(1), tween.Overflow)
 	assert.True(t, isFinished)
-
 }
 
-func TestSequence(t *testing.T) {
-
-	seq := NewSequence(
-		New(0, 5, 1, ease.Linear),
-		New(5, 0, 1, ease.Linear),
-		New(0, 2, 2, ease.Linear),
-		New(2, 0, 2, ease.Linear),
-		New(0, 1, 100, ease.Linear),
-	)
-
-	assert.True(t, len(seq.Tweens) == 5)
-	seq.Remove(0)
-	seq.Remove(0)
-	assert.True(t, len(seq.Tweens) == 3)
-
-	current, finishedTween, sequenceFinished := seq.Update(1)
-	// Half-way through first tween
-	assert.Equal(t, float32(1), current)
-	assert.False(t, finishedTween)
-	assert.False(t, sequenceFinished)
-
-	current, finishedTween, sequenceFinished = seq.Update(1)
-	// Now at the start of the second tween
+func TestTween_UpdateZero(t *testing.T) {
+	tween := New(0, 10, 10, ease.Linear)
+	tween.Update(2)
+	current, isFinished := tween.Update(0)
 	assert.Equal(t, float32(2), current)
-	assert.Equal(t, seq.Index(), 1)
-	assert.True(t, finishedTween)
-	assert.False(t, sequenceFinished)
+	assert.False(t, isFinished)
+}
 
-	current, finishedTween, sequenceFinished = seq.Update(2)
-	// Now at the start of the third Tween
-	assert.Equal(t, seq.Index(), 2)
-	assert.False(t, sequenceFinished)
-
-	seq.Remove(2)
-	current, finishedTween, sequenceFinished = seq.Update(1)
-	// Now finished because we removed the third tween and then called Sequence.Update()
-	assert.False(t, finishedTween)
-	assert.True(t, sequenceFinished)
+func TestTween_UpdateNeg(t *testing.T) {
+	tween := New(0, 10, 10, ease.Linear)
+	tween.Update(2)
+	current, isFinished := tween.Update(-1)
+	assert.Equal(t, float32(1), current)
+	assert.False(t, isFinished)
 }

--- a/sequence.go
+++ b/sequence.go
@@ -21,35 +21,32 @@ func (seq *Sequence) Add(tweens ...*Tween) {
 
 // Remove removes a Tween of the specified index from the Sequence.
 func (seq *Sequence) Remove(index int) {
-	seq.Tweens = append(seq.Tweens[:index], seq.Tweens[index+1:]...)
+	if !(index >= len(seq.Tweens) || index < 0) {
+		seq.Tweens = append(seq.Tweens[:index], seq.Tweens[index+1:]...)
+	}
 }
 
 // Update updates the currently active Tween in the Sequence; once that Tween is done, the Sequence moves onto the next one.
 // Update() returns the current Tween's output, whether that Tween is complete, and whether the entire Sequence is complete.
 func (seq *Sequence) Update(dt float32) (float32, bool, bool) {
 
-	value := float32(0.0)
-	tweenComplete := false
-	sequenceComplete := false
+	var completed []int
+	remaining := dt
 
-	if seq.index < len(seq.Tweens) {
-
-		value, tweenComplete = seq.Tweens[seq.index].Update(dt)
-
-		if tweenComplete {
+	for {
+		if seq.index >= len(seq.Tweens) {
+			return seq.Tweens[len(seq.Tweens)-1].end, len(completed) > 0, true
+		}
+		v, tc := seq.Tweens[seq.index].Update(remaining)
+		if tc {
+			remaining = seq.Tweens[seq.index].Overflow
+			completed = append(completed, seq.index)
 			seq.Tweens[seq.index].Reset()
 			seq.index++
-			if seq.index >= len(seq.Tweens) {
-				sequenceComplete = true
-			}
+		} else {
+			return v, len(completed) > 0, false
 		}
-
-	} else {
-		sequenceComplete = true
 	}
-
-	return value, tweenComplete, sequenceComplete
-
 }
 
 // Index returns the current index of the Sequence. Note that this can exceed the number of Tweens in the Sequence.

--- a/sequence.go
+++ b/sequence.go
@@ -21,7 +21,7 @@ func (seq *Sequence) Add(tweens ...*Tween) {
 
 // Remove removes a Tween of the specified index from the Sequence.
 func (seq *Sequence) Remove(index int) {
-	if !(index >= len(seq.Tweens) || index < 0) {
+	if index >= 0 && index < len(seq.Tweens) {
 		seq.Tweens = append(seq.Tweens[:index], seq.Tweens[index+1:]...)
 	}
 }

--- a/sequence_test.go
+++ b/sequence_test.go
@@ -1,0 +1,178 @@
+package gween
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/tanema/gween/ease"
+)
+
+func TestSequenceNew(t *testing.T) {
+	seq := NewSequence(New(0, 1, 1, ease.Linear))
+
+	current, finishedTween, seqFinished := seq.Update(0.0)
+	assert.Equal(t, float32(0), current)
+	assert.False(t, finishedTween)
+	assert.False(t, seqFinished)
+	assert.Equal(t, 0, seq.index)
+}
+
+func TestSequence_Update(t *testing.T) {
+	seq := NewSequence(
+		New(0, 1, 1, ease.Linear),
+		New(1, 2, 1, ease.Linear),
+	)
+
+	current, finishedTween, seqFinished := seq.Update(0.5)
+	assert.Equal(t, float32(0.5), current)
+	assert.False(t, finishedTween)
+	assert.False(t, seqFinished)
+	assert.Equal(t, 0, seq.index)
+}
+
+func TestSequence_Reset(t *testing.T) {
+	seq := NewSequence(
+		New(0, 1, 1, ease.Linear),
+		New(1, 2, 1, ease.Linear),
+	)
+
+	seq.Update(1.5)
+	seq.Reset()
+	assert.Equal(t, 0, seq.index)
+	assert.Equal(t, float32(0.0), seq.Tweens[0].time)
+	assert.Equal(t, float32(0.0), seq.Tweens[0].Overflow)
+	assert.Equal(t, float32(0.0), seq.Tweens[1].time)
+	assert.Equal(t, float32(0.0), seq.Tweens[1].Overflow)
+}
+
+func TestSequence_CompleteFirst(t *testing.T) {
+	seq := NewSequence(
+		New(0, 1, 1, ease.Linear),
+		New(1, 2, 1, ease.Linear),
+	)
+
+	current, finishedTween, seqFinished := seq.Update(1.0)
+	assert.Equal(t, float32(1.0), current)
+	assert.True(t, finishedTween)
+	assert.False(t, seqFinished)
+	assert.Equal(t, 1, seq.index)
+}
+
+func TestSequence_OverflowSecond(t *testing.T) {
+	seq := NewSequence(
+		New(0, 1, 1, ease.Linear),
+		New(1, 2, 1, ease.Linear),
+	)
+
+	current, finishedTween, seqFinished := seq.Update(1.5)
+	assert.Equal(t, float32(1.5), current)
+	assert.True(t, finishedTween)
+	assert.False(t, seqFinished)
+	assert.Equal(t, 1, seq.index)
+}
+
+func TestSequence_OverflowAndComplete(t *testing.T) {
+	seq := NewSequence(
+		New(0, 1, 1, ease.Linear),
+		New(1, 2, 1, ease.Linear),
+		New(2, 3, 1, ease.Linear),
+	)
+
+	current, finishedTween, seqFinished := seq.Update(3.5)
+	assert.Equal(t, float32(3.0), current)
+	assert.True(t, finishedTween)
+	assert.True(t, seqFinished)
+	assert.Equal(t, 3, seq.index)
+}
+
+func TestSequence_Remove(t *testing.T) {
+	seq := NewSequence(
+		New(0, 1, 1, ease.Linear),
+		New(1, 2, 1, ease.Linear),
+		New(2, 3, 1, ease.Linear),
+		New(3, 4, 1, ease.Linear),
+		New(4, 5, 1, ease.Linear),
+	)
+	assert.Equal(t, 5, len(seq.Tweens))
+	seq.Remove(2)
+	assert.Equal(t, 4, len(seq.Tweens))
+	current, finishedTween, seqFinished := seq.Update(2.5)
+	assert.Equal(t, float32(3.5), current)
+	assert.True(t, finishedTween)
+	assert.False(t, seqFinished)
+	assert.Equal(t, 2, seq.index)
+	seq.Remove(0)
+	assert.Equal(t, 3, len(seq.Tweens))
+	seq.Remove(0)
+	assert.Equal(t, 2, len(seq.Tweens))
+	seq.Remove(0)
+	assert.Equal(t, 1, len(seq.Tweens))
+	// Out of bound checking
+	seq.Remove(0)
+	assert.Equal(t, 0, len(seq.Tweens))
+	seq.Remove(2)
+	assert.Equal(t, 0, len(seq.Tweens))
+}
+
+func TestSequence_Has(t *testing.T) {
+	seq := NewSequence()
+	assert.False(t, seq.HasTweens())
+	seq.Add(New(0, 5, 1, ease.Linear))
+	assert.True(t, seq.HasTweens())
+	seq.Remove(0)
+	assert.False(t, seq.HasTweens())
+}
+
+func TestSequence_SetIndex(t *testing.T) {
+	seq := NewSequence(
+		New(0, 1, 1, ease.Linear),
+		New(1, 2, 1, ease.Linear),
+	)
+	seq.SetIndex(1)
+	current, finishedTween, seqFinished := seq.Update(1.5)
+	assert.Equal(t, float32(2), current)
+	assert.True(t, finishedTween)
+	assert.True(t, seqFinished)
+	assert.Equal(t, 2, seq.index)
+}
+
+func TestSequence_RealWorld(t *testing.T) {
+
+	seq := NewSequence(
+		New(0, 5, 1, ease.Linear),
+		New(5, 0, 1, ease.Linear),
+		New(0, 2, 2, ease.Linear),
+		New(2, 0, 2, ease.Linear),
+		New(0, 1, 100, ease.Linear),
+	)
+
+	assert.True(t, len(seq.Tweens) == 5)
+	seq.Remove(0)
+	seq.Remove(0)
+	assert.True(t, len(seq.Tweens) == 3)
+
+	current, finishedTween, sequenceFinished := seq.Update(1)
+	// Half-way through first tween
+	assert.Equal(t, float32(1), current)
+	assert.False(t, finishedTween)
+	assert.False(t, sequenceFinished)
+
+	current, finishedTween, sequenceFinished = seq.Update(1)
+	// Now at the start of the second tween
+	assert.Equal(t, float32(2), current)
+	assert.Equal(t, seq.Index(), 1)
+	assert.True(t, finishedTween)
+	assert.False(t, sequenceFinished)
+
+	current, finishedTween, sequenceFinished = seq.Update(2)
+	// Now at the start of the third Tween
+	assert.Equal(t, seq.Index(), 2)
+	assert.False(t, sequenceFinished)
+
+	seq.Remove(2)
+	current, finishedTween, sequenceFinished = seq.Update(1)
+	// Now finished because we removed the third tween and then called Sequence.Update()
+	assert.False(t, finishedTween)
+	assert.True(t, sequenceFinished)
+}


### PR DESCRIPTION
I've been using this lib in a project and noticed some time drift on occasion. Hope you're taking PRs ;)

Changes:
 - Tweens now track overflow amount from the last update / set
 - Sequence.Update now spills over to the next Tween with the overflow amount until `dt` is completely exhausted
 - Sequence.Remove will no longer panic when provided an out of bounds index
 - Test Coverage is now ~97.2%, up from ~92.6%; only missing a few lines in easing_functions.go
 - Fixed a pair of typos