### PR TITLE
Adding SetReverse() function on Sequence

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,27 @@ Resets all tweens in the sequence and sets the "current" tween back to the first
 sets the remaining loop count back to the initial value last set using the 
 `.SetLoop()` function (or `1` if using the default).
 
+```golang
+s.SetReverse(bool)
+```
+Defaults to `false`
+
+Configures the sequence to run in "reverse" or not.
+
+* When `yoyo` is `false`:
+  * If `reverse` is `false`, the sequence will run forward and will loop back to
+  the beginning if available
+  * If `reverse` is `true`, the sequence will run backward and will loop back to
+  the end if available
+* When `yoyo` is `true`:
+  * The sequence will run according to normal yoyo logic. If a sequence has gone
+  from the start to the end, and is coming back to the start (reverse is true) 
+  and you set reverse to false, then the sequence will start heading towards the
+  end again. When it reaches the end it will simply yoyo as expected. The inverse
+  is also true, if the sequence is heading to the end and you reverse it before
+  the end, it'll simply head toward the start and if it reaches the start it will
+  consume a loop and, if possible, start again.
+
 
 ```golang
 s.Add(tweens ...*Tween)

--- a/ease/easing_functions.go
+++ b/ease/easing_functions.go
@@ -11,21 +11,30 @@ var pi = float32(math.Pi)
 
 // TweenFunc provides an interface used for the easing equation. You can use
 // one of the provided easing functions or provide your own.
+// t = current time, b = begin value, c = change from begin, d = duration
 type TweenFunc func(t, b, c, d float32) float32
 
+// Linear is a linear interpolation of some t with respect to a total duration d
+// between the values b and b+c
 func Linear(t, b, c, d float32) float32 {
 	return c*t/d + b
 }
 
+// InQuad is a quadratic transition based on the square of t that starts slow
+// and speeds up
 func InQuad(t, b, c, d float32) float32 {
 	return c*pow(t/d, 2) + b
 }
 
+// OutQuad is a quadratic transition based on the square of t that starts fast
+// and slows down
 func OutQuad(t, b, c, d float32) float32 {
-	t = t / d
+	t /= d
 	return -c*t*(t-2) + b
 }
 
+// InOutQuad is a quadratic transition based on the square of t that starts and
+// ends slow, accelerating through the middle
 func InOutQuad(t, b, c, d float32) float32 {
 	t = t / d * 2
 	if t < 1 {
@@ -34,6 +43,8 @@ func InOutQuad(t, b, c, d float32) float32 {
 	return -c/2*((t-1)*(t-3)-1) + b
 }
 
+// OutInQuad is a quadratic transition based on the square of t that starts and
+// ends fast, slowing through the middle
 func OutInQuad(t, b, c, d float32) float32 {
 	if t < d/2 {
 		return OutQuad(t*2, b, c/2, d)
@@ -41,23 +52,31 @@ func OutInQuad(t, b, c, d float32) float32 {
 	return InQuad((t*2)-d, b+c/2, c/2, d)
 }
 
+// InCubic is a cubic transition based on the cube of t that starts slow and
+// speeds up
 func InCubic(t, b, c, d float32) float32 {
 	return c*pow(t/d, 3) + b
 }
 
+// OutCubic is a cubic transition based on the cube of t that starts fast and
+// slows down
 func OutCubic(t, b, c, d float32) float32 {
 	return c*(pow(t/d-1, 3)+1) + b
 }
 
+// InOutCubic is a cubic transition based on the cube of t that starts and ends
+// slow, accelerating through the middle
 func InOutCubic(t, b, c, d float32) float32 {
 	t = t / d * 2
 	if t < 1 {
 		return c/2*t*t*t + b
 	}
-	t = t - 2
+	t -= 2
 	return c/2*(t*t*t+2) + b
 }
 
+// OutInCubic is a cubic transition based on the cube of t that starts and ends
+// fast, slowing through the middle
 func OutInCubic(t, b, c, d float32) float32 {
 	if t < d/2 {
 		return OutCubic(t*2, b, c/2, d)
@@ -65,14 +84,20 @@ func OutInCubic(t, b, c, d float32) float32 {
 	return InCubic((t*2)-d, b+c/2, c/2, d)
 }
 
+// InQuart is a quartic transition based on the fourth power of t that starts
+// slow and speeds up
 func InQuart(t, b, c, d float32) float32 {
 	return c*pow(t/d, 4) + b
 }
 
+// OutQuart is a quartic transition based on the fourth power of t that starts
+// fast and slows down
 func OutQuart(t, b, c, d float32) float32 {
 	return -c*(pow(t/d-1, 4)-1) + b
 }
 
+// InOutQuart is a quartic transition based on the fourth power of t that starts
+// and ends slow, accelerating through the middle
 func InOutQuart(t, b, c, d float32) float32 {
 	t = t / d * 2
 	if t < 1 {
@@ -81,6 +106,8 @@ func InOutQuart(t, b, c, d float32) float32 {
 	return -c/2*(pow(t-2, 4)-2) + b
 }
 
+// OutInQuart is a quartic transition based on the fourth power of t that starts
+// and ends fast, slowing through the middle
 func OutInQuart(t, b, c, d float32) float32 {
 	if t < d/2 {
 		return OutQuart(t*2, b, c/2, d)
@@ -88,14 +115,20 @@ func OutInQuart(t, b, c, d float32) float32 {
 	return InQuart((t*2)-d, b+c/2, c/2, d)
 }
 
+// InQuint is a quintic transition based on the fifth power of t that starts
+// slow and speeds up
 func InQuint(t, b, c, d float32) float32 {
 	return c*pow(t/d, 5) + b
 }
 
+// OutQuint is a quintic transition based on the fifth power of t that starts
+// fast and slows down
 func OutQuint(t, b, c, d float32) float32 {
 	return c*(pow(t/d-1, 5)+1) + b
 }
 
+// InOutQuint is a quintic transition based on the fifth power of t that starts
+// and ends slow, accelerating through the middle
 func InOutQuint(t, b, c, d float32) float32 {
 	t = t / d * 2
 	if t < 1 {
@@ -104,6 +137,8 @@ func InOutQuint(t, b, c, d float32) float32 {
 	return c/2*(pow(t-2, 5)+2) + b
 }
 
+// OutInQuint is a quintic transition based on the fifth power of t that starts
+// and ends fast, slowing through the middle
 func OutInQuint(t, b, c, d float32) float32 {
 	if t < d/2 {
 		return OutQuint(t*2, b, c/2, d)
@@ -111,18 +146,26 @@ func OutInQuint(t, b, c, d float32) float32 {
 	return InQuint((t*2)-d, b+c/2, c/2, d)
 }
 
+// InSine is a sinusoidal transition based on the cosine of t that starts slow
+// and speeds up
 func InSine(t, b, c, d float32) float32 {
 	return -c*cos(t/d*(pi/2)) + c + b
 }
 
+// OutSine is a sinusoidal transition based on the sine or cosine of t that
+// starts fast and slows down
 func OutSine(t, b, c, d float32) float32 {
 	return c*sin(t/d*(pi/2)) + b
 }
 
+// InOutSine is a sinusoidal transition based on the cosine of t that starts and
+// ends slow, accelerating through the middle
 func InOutSine(t, b, c, d float32) float32 {
 	return -c/2*(cos(pi*t/d)-1) + b
 }
 
+// OutInSine is a sinusoidal transition based on the sine or cosine of t that
+// starts and ends fast, slowing through the middle
 func OutInSine(t, b, c, d float32) float32 {
 	if t < d/2 {
 		return OutSine(t*2, b, c/2, d)
@@ -130,6 +173,8 @@ func OutInSine(t, b, c, d float32) float32 {
 	return InSine((t*2)-d, b+c/2, c/2, d)
 }
 
+// InExpo is a exponential transition based on the 2 to power 10*t that starts
+// slow and speeds up
 func InExpo(t, b, c, d float32) float32 {
 	if t == 0 {
 		return b
@@ -137,6 +182,8 @@ func InExpo(t, b, c, d float32) float32 {
 	return c*pow(2, 10*(t/d-1)) + b - c*0.001
 }
 
+// OutExpo is a exponential transition based on the 2 to power 10*t that starts
+// fast and slows down
 func OutExpo(t, b, c, d float32) float32 {
 	if t == d {
 		return b + c
@@ -144,6 +191,8 @@ func OutExpo(t, b, c, d float32) float32 {
 	return c*1.001*(-pow(2, -10*t/d)+1) + b
 }
 
+// InOutExpo is a exponential transition based on the 2 to power 10*t that
+// starts and ends slow, accelerating through the middle
 func InOutExpo(t, b, c, d float32) float32 {
 	if t == 0 {
 		return b
@@ -158,6 +207,8 @@ func InOutExpo(t, b, c, d float32) float32 {
 	return c/2*1.0005*(-pow(2, -10*(t-1))+2) + b
 }
 
+// OutInExpo is a exponential transition based on the 2 to power 10*t that
+// starts and ends fast, slowing through the middle
 func OutInExpo(t, b, c, d float32) float32 {
 	if t < d/2 {
 		return OutExpo(t*2, b, c/2, d)
@@ -165,23 +216,33 @@ func OutInExpo(t, b, c, d float32) float32 {
 	return InExpo((t*2)-d, b+c/2, c/2, d)
 }
 
+// InCirc is a circular transition based on the equation for half of a circle,
+// taking the square root of t, that starts slow and speeds up
 func InCirc(t, b, c, d float32) float32 {
-	return (-c*(sqrt(1-pow(t/d, 2))-1) + b)
+	return -c*(sqrt(1-pow(t/d, 2))-1) + b
 }
 
+// OutCirc is a circular transition based on the equation for half of a circle,
+// taking the square root of t, that starts fast and slows down
 func OutCirc(t, b, c, d float32) float32 {
-	return (c*sqrt(1-pow(t/d-1, 2)) + b)
+	return c*sqrt(1-pow(t/d-1, 2)) + b
 }
 
+// InOutCirc is a circular transition based on the equation for half of a circle,
+// taking the square root of t, that starts and ends slow, accelerating through
+// the middle
 func InOutCirc(t, b, c, d float32) float32 {
 	t = t / d * 2
 	if t < 1 {
 		return -c/2*(sqrt(1-t*t)-1) + b
 	}
-	t = t - 2
+	t -= 2
 	return c/2*(sqrt(1-t*t)+1) + b
 }
 
+// OutInCirc is a circular transition based on the equation for half of a circle,
+// taking the square root of t, that starts and ends fast, slowing through the
+// middle
 func OutInCirc(t, b, c, d float32) float32 {
 	if t < d/2 {
 		return OutCirc(t*2, b, c/2, d)
@@ -189,24 +250,30 @@ func OutInCirc(t, b, c, d float32) float32 {
 	return InCirc((t*2)-d, b+c/2, c/2, d)
 }
 
+// InElastic is an elastic transition that wobbles around from the start value,
+// extending past start and away from end, and then accelerates towards the end
+// value at the end of the transition.
 func InElastic(t, b, c, d float32) float32 {
 	if t == 0 {
 		return b
 	}
-	t = t / d
+	t /= d
 	if t == 1 {
 		return b + c
 	}
 	p, a, s := calculatePAS(c, d)
-	t = t - 1
+	t--
 	return -(a * pow(2, 10*t) * sin((t*d-s)*(2*pi)/p)) + b
 }
 
+// OutElastic is an elastic transition that accelerates quickly away from the
+// start and beyond the end value and then wobbles towards the end value at the
+// end of the transition.
 func OutElastic(t, b, c, d float32) float32 {
 	if t == 0 {
 		return b
 	}
-	t = t / d
+	t /= d
 	if t == 1 {
 		return b + c
 	}
@@ -214,6 +281,9 @@ func OutElastic(t, b, c, d float32) float32 {
 	return a*pow(2, -10*t)*sin((t*d-s)*(2*pi)/p) + c + b
 }
 
+// InOutElastic is an elastic transition that wobbles around from the start
+// value, towards the middle of the transition extending beyond start away from
+// end, then rapidly toward, and beyond end value, then wobbling toward end
 func InOutElastic(t, b, c, d float32) float32 {
 	if t == 0 {
 		return b
@@ -223,13 +293,16 @@ func InOutElastic(t, b, c, d float32) float32 {
 		return b + c
 	}
 	p, a, s := calculatePAS(c, d)
-	t = t - 1
+	t--
 	if t < 0 {
 		return -0.5*(a*pow(2, 10*t)*sin((t*d-s)*(2*pi)/p)) + b
 	}
 	return a*pow(2, -10*t)*sin((t*d-s)*(2*pi)/p)*0.5 + c + b
 }
 
+// OutInElastic is an elastic transition that accelerates towards and beyond the
+// average of the start and end values, wobbles toward the average, wobbles out
+// and slight away from end before accelerating toward the end value
 func OutInElastic(t, b, c, d float32) float32 {
 	if t < d/2 {
 		return OutElastic(t*2, b, c/2, d)
@@ -237,26 +310,34 @@ func OutInElastic(t, b, c, d float32) float32 {
 	return InElastic((t*2)-d, b+c/2, c/2, d)
 }
 
+// InBack is a much like InQuint, but extends beyond the start away from end
+// before snapping quickly to the end
 func InBack(t, b, c, d float32) float32 {
-	t = t / d
+	t /= d
 	return c*t*t*((backS+1)*t-backS) + b
 }
 
+// OutBack is a much like OutQuint, but extends beyond the end away from start
+// before easing toward end
 func OutBack(t, b, c, d float32) float32 {
 	t = t/d - 1
 	return c*(t*t*((backS+1)*t+backS)+1) + b
 }
 
+// InOutBack is a much like InOutQuint, but extends beyond both start and end
+// values on both sides of the transition
 func InOutBack(t, b, c, d float32) float32 {
 	s := backS * 1.525
 	t = t / d * 2
 	if t < 1 {
 		return c/2*(t*t*((s+1)*t-s)) + b
 	}
-	t = t - 2
+	t -= 2
 	return c/2*(t*t*((s+1)*t+s)+2) + b
 }
 
+// OutInBack is a much like OutInQuint, but extends beyond the average of start
+// and end during the middle of the transition
 func OutInBack(t, b, c, d float32) float32 {
 	if t < (d / 2) {
 		return OutBack(t*2, b, c/2, d)
@@ -264,26 +345,33 @@ func OutInBack(t, b, c, d float32) float32 {
 	return InBack((t*2)-d, b+c/2, c/2, d)
 }
 
+// OutBounce is a bouncing transition that accelerates toward the end value and
+// then bounces back slightly in decreasing amounts until coming to reset at end
 func OutBounce(t, b, c, d float32) float32 {
-	t = t / d
+	t /= d
 	if t < 1/2.75 {
 		return c*(7.5625*t*t) + b
 	}
 	if t < 2/2.75 {
-		t = t - (1.5 / 2.75)
+		t -= 1.5 / 2.75
 		return c*(7.5625*t*t+0.75) + b
 	} else if t < 2.5/2.75 {
-		t = t - (2.25 / 2.75)
+		t -= 2.25 / 2.75
 		return c*(7.5625*t*t+0.9375) + b
 	}
-	t = t - (2.625 / 2.75)
+	t -= 2.625 / 2.75
 	return c*(7.5625*t*t+0.984375) + b
 }
 
+// InBounce is a bouncing transition that slowly bounces away from start at
+// increasing amounts before finally accelerating toward end
 func InBounce(t, b, c, d float32) float32 {
 	return c - OutBounce(d-t, 0, c, d) + b
 }
 
+// InOutBounce is a bouncing transition that bounces off of the start value,
+// then accelerates toward the average of start and end, then does the opposite
+// toward the end value
 func InOutBounce(t, b, c, d float32) float32 {
 	if t < d/2 {
 		return InBounce(t*2, 0, c, d)*0.5 + b
@@ -291,6 +379,10 @@ func InOutBounce(t, b, c, d float32) float32 {
 	return OutBounce(t*2-d, 0, c, d)*0.5 + c*.5 + b
 }
 
+// OutInBounce is a bouncing transition that accelerates toward the average of
+// start and end, bouncing off of the average toward start, then flips and
+// bounces off of average toward end in increasing amounts before accelerating
+// toward end
 func OutInBounce(t, b, c, d float32) float32 {
 	if t < d/2 {
 		return OutBounce(t*2, b, c/2, d)

--- a/gween.go
+++ b/gween.go
@@ -39,15 +39,16 @@ func New(begin, end, duration float32, easing ease.TweenFunc) *Tween {
 // Set will set the current time along the duration of the tween. It will then return
 // the current value as well as a boolean to determine if the tween is finished.
 func (tween *Tween) Set(time float32) (current float32, isFinished bool) {
-	if time <= 0 {
+	switch {
+	case time <= 0:
 		tween.Overflow = time
 		tween.time = 0
 		current = tween.begin
-	} else if time >= tween.duration {
+	case time >= tween.duration:
 		tween.Overflow = time - tween.duration
 		tween.time = tween.duration
 		current = tween.end
-	} else {
+	default:
 		tween.Overflow = 0
 		tween.time = time
 		current = tween.easing(tween.time, tween.begin, tween.change, tween.duration)

--- a/gween_test.go
+++ b/gween_test.go
@@ -140,10 +140,10 @@ func TestTween_CanReverse(t *testing.T) {
 
 func TestTween_CanReverseFromFinished(t *testing.T) {
 	tween := New(0, 10, 10, ease.Linear)
-	current, isFinished := tween.Update(10)
+	_, isFinished := tween.Update(10)
 	assert.True(t, isFinished)
 	tween.reverse = true
-	current, isFinished = tween.Update(2)
+	current, isFinished := tween.Update(2)
 	assert.Equal(t, float32(8), current)
 	assert.False(t, isFinished)
 }

--- a/gween_test.go
+++ b/gween_test.go
@@ -115,6 +115,15 @@ func TestTween_UpdateNeg(t *testing.T) {
 	assert.False(t, isFinished)
 }
 
+func TestTween_UpdateNegReverse(t *testing.T) {
+	tween := New(0, 10, 10, ease.Linear)
+	tween.Update(2)
+	tween.reverse = true
+	current, isFinished := tween.Update(-1)
+	assert.Equal(t, float32(3), current)
+	assert.False(t, isFinished)
+}
+
 func TestTween_Defaults_Forward(t *testing.T) {
 	tween := New(0, 10, 10, ease.Linear)
 	assert.False(t, tween.reverse)

--- a/sequence.go
+++ b/sequence.go
@@ -47,25 +47,45 @@ func (seq *Sequence) Update(dt float32) (float32, bool, bool) {
 	}
 	var completed []int
 	remaining := dt
-	yoyoed := false
 
 	for {
-		// Yoyoing never gets out of bounds
-		if (yoyoed && seq.index == 0) || seq.index >= len(seq.Tweens) || seq.index <= -1 {
+		if seq.yoyo {
+			if seq.index < 0 {
+				// Out of bounds at beginnning, loop
+				seq.reverse = false
+				seq.index = seq.clampIndex(seq.index)
+				if seq.loopRemaining >= 1 {
+					seq.loopRemaining -= 1
+				}
+				if seq.loopRemaining == 0 || remaining == 0 {
+					return seq.Tweens[seq.index].begin, len(completed) > 0, true
+				}
+				seq.Tweens[seq.index].reverse = seq.Reverse()
+				seq.Tweens[seq.index].Reset()
+			}
+			if seq.index >= len(seq.Tweens) {
+				// Out of bounds at end, yoyo
+				seq.reverse = true
+				seq.index = seq.clampIndex(seq.index)
+
+				seq.Tweens[seq.index].reverse = seq.Reverse()
+				seq.Tweens[seq.index].Reset()
+			}
+		} else if seq.index >= len(seq.Tweens) || seq.index <= -1 {
+			// out of bounds at either end, loop
 			if seq.loopRemaining >= 1 {
 				seq.loopRemaining -= 1
 			}
 			if seq.loopRemaining == 0 || remaining == 0 {
-				index := seq.index
-				if index >= len(seq.Tweens) {
-					index = len(seq.Tweens) - 1
+				if seq.reverse {
+					return seq.Tweens[seq.clampIndex(seq.index)].begin, len(completed) > 0, true
+				} else {
+					return seq.Tweens[seq.clampIndex(seq.index)].end, len(completed) > 0, true
 				}
-				if yoyoed && seq.index == 0 {
-					return seq.Tweens[index].begin, len(completed) > 0, true
-				}
-				return seq.Tweens[index].end, len(completed) > 0, true
 			}
-			seq.index = 0
+			seq.index = seq.wrapIndex(seq.index)
+			seq.Tweens[seq.index].reverse = seq.Reverse()
+			seq.Tweens[seq.index].Reset()
 		}
 		v, tc := seq.Tweens[seq.index].Update(remaining)
 		if !tc {
@@ -73,39 +93,20 @@ func (seq *Sequence) Update(dt float32) (float32, bool, bool) {
 		}
 		remaining = seq.Tweens[seq.index].Overflow
 		completed = append(completed, seq.index)
-		yoyoed = seq.yoyoed()
-		seq.Tweens[seq.index].reverse = seq.Reverse()
-		seq.Tweens[seq.index].Reset()
 		if remaining < 0 {
 			remaining *= -1
 		}
-		if !yoyoed {
-			if seq.reverse {
-				seq.index--
-			} else {
-				seq.index++
-			}
-			// On the way back, tweens need to be configured to not go forward
-			if seq.index < len(seq.Tweens) && seq.index >= 0 {
-				seq.Tweens[seq.index].reverse = seq.Reverse()
-				seq.Tweens[seq.index].Reset()
-			}
+		if seq.reverse {
+			seq.index--
+		} else {
+			seq.index++
+		}
+		// On the way back, tweens need to be configured to not go forward
+		if seq.index < len(seq.Tweens) && seq.index >= 0 {
+			seq.Tweens[seq.index].reverse = seq.Reverse()
+			seq.Tweens[seq.index].Reset()
 		}
 	}
-}
-
-func (seq *Sequence) yoyoed() bool {
-	if seq.yoyo {
-		if seq.index == len(seq.Tweens)-1 && seq.Tweens[seq.index].reverse == false {
-			seq.reverse = true
-			return true
-		}
-		if seq.index == 0 && seq.Tweens[seq.index].reverse == true {
-			seq.reverse = false
-			return true
-		}
-	}
-	return false
 }
 
 // Index returns the current index of the Sequence. Note that this can exceed the number of Tweens in the Sequence.
@@ -148,4 +149,34 @@ func (seq *Sequence) HasTweens() bool {
 // Reverse returns whether the Sequence currently running in reverse.
 func (seq *Sequence) Reverse() bool {
 	return seq.reverse
+}
+
+// SetReverse sets whether the Sequence will start running in reverse.
+func (seq *Sequence) SetReverse(r bool) {
+	if seq.index < len(seq.Tweens) && seq.index >= 0 {
+		seq.Tweens[seq.index].reverse = r
+	}
+	seq.reverse = r
+}
+
+// clampIndex clamps the provided index to the bounds of the Tweens slice
+func (seq *Sequence) clampIndex(index int) int {
+	if index >= len(seq.Tweens) {
+		index = len(seq.Tweens) - 1
+	}
+	if index < 0 {
+		index = 0
+	}
+	return index
+}
+
+// wrapIndex wraps the provided index when it is out of bounds, otherwise returns index
+func (seq *Sequence) wrapIndex(index int) int {
+	if index >= len(seq.Tweens) {
+		index = 0
+	}
+	if index < 0 {
+		index = len(seq.Tweens) - 1
+	}
+	return index
 }

--- a/sequence.go
+++ b/sequence.go
@@ -152,9 +152,10 @@ func (seq *Sequence) Reverse() bool {
 
 // SetReverse sets whether the Sequence will start running in reverse.
 func (seq *Sequence) SetReverse(r bool) {
-	if seq.index < len(seq.Tweens) && seq.index >= 0 {
-		seq.Tweens[seq.index].reverse = r
+	if seq.index >= len(seq.Tweens) || seq.index < 0 {
+		seq.index = seq.clampIndex(seq.index)
 	}
+	seq.Tweens[seq.index].reverse = r
 	seq.reverse = r
 }
 

--- a/sequence.go
+++ b/sequence.go
@@ -41,7 +41,7 @@ func (seq *Sequence) Remove(index int) {
 // Update updates the currently active Tween in the Sequence; once that Tween is done, the Sequence moves onto the next one.
 // Update() returns the current Tween's output, whether that Tween is complete, and whether the entire Sequence was completed
 // during this Update.
-func (seq *Sequence) Update(dt float32) (float32, bool, bool) {
+func (seq *Sequence) Update(dt float32) (value float32, tweenComplete, sequenceComplete bool) {
 	if !seq.HasTweens() {
 		return 0, false, true
 	}
@@ -55,7 +55,7 @@ func (seq *Sequence) Update(dt float32) (float32, bool, bool) {
 				seq.reverse = false
 				seq.index = seq.clampIndex(seq.index)
 				if seq.loopRemaining >= 1 {
-					seq.loopRemaining -= 1
+					seq.loopRemaining--
 				}
 				if seq.loopRemaining == 0 || remaining == 0 {
 					return seq.Tweens[seq.index].begin, len(completed) > 0, true
@@ -74,14 +74,13 @@ func (seq *Sequence) Update(dt float32) (float32, bool, bool) {
 		} else if seq.index >= len(seq.Tweens) || seq.index <= -1 {
 			// out of bounds at either end, loop
 			if seq.loopRemaining >= 1 {
-				seq.loopRemaining -= 1
+				seq.loopRemaining--
 			}
 			if seq.loopRemaining == 0 || remaining == 0 {
 				if seq.reverse {
 					return seq.Tweens[seq.clampIndex(seq.index)].begin, len(completed) > 0, true
-				} else {
-					return seq.Tweens[seq.clampIndex(seq.index)].end, len(completed) > 0, true
 				}
+				return seq.Tweens[seq.clampIndex(seq.index)].end, len(completed) > 0, true
 			}
 			seq.index = seq.wrapIndex(seq.index)
 			seq.Tweens[seq.index].reverse = seq.Reverse()

--- a/sequence_test.go
+++ b/sequence_test.go
@@ -278,6 +278,35 @@ func TestSequence_SetReverseWithYoyo(t *testing.T) {
 	assert.Equal(t, 0, seq.index)
 }
 
+func TestSequence_SetReverseAfterComplete(t *testing.T) {
+	seq := NewSequence(
+		New(0, 1, 1, ease.Linear),
+		New(1, 2, 1, ease.Linear),
+		New(2, 3, 1, ease.Linear),
+	)
+	seq.SetLoop(1)
+
+	// Normal operation
+	current, finishedTween, seqFinished := seq.Update(3.0)
+	assert.Equal(t, float32(3.0), current)
+	assert.True(t, finishedTween)
+	assert.True(t, seqFinished)
+	assert.Equal(t, 0, seq.loopRemaining)
+	assert.Equal(t, 3, seq.index)
+
+	seq.SetReverse(true)
+	seq.SetLoop(1)
+
+	// Goes in reverse
+	current, finishedTween, seqFinished = seq.Update(2.0)
+	assert.Equal(t, float32(1.0), current)
+	assert.True(t, finishedTween)
+	assert.False(t, seqFinished)
+	assert.Equal(t, 1, seq.loopRemaining)
+	assert.Equal(t, 0, seq.index)
+	assert.True(t, seq.Reverse())
+}
+
 func TestSequence_Remove(t *testing.T) {
 	seq := NewSequence(
 		New(0, 1, 1, ease.Linear),

--- a/sequence_test.go
+++ b/sequence_test.go
@@ -129,6 +129,7 @@ func TestSequence_Yoyos(t *testing.T) {
 		New(1, 2, 1, ease.Linear),
 		New(2, 3, 1, ease.Linear),
 	)
+
 	seq.SetYoyo(true)
 	current, finishedTween, seqFinished := seq.Update(5.75)
 	assert.Equal(t, float32(0.25), current)
@@ -360,13 +361,13 @@ func TestSequence_RealWorld(t *testing.T) {
 	assert.True(t, finishedTween)
 	assert.False(t, sequenceFinished)
 
-	current, finishedTween, sequenceFinished = seq.Update(2)
+	_, _, sequenceFinished = seq.Update(2)
 	// Now at the start of the third Tween
 	assert.Equal(t, seq.Index(), 2)
 	assert.False(t, sequenceFinished)
 
 	seq.Remove(2)
-	current, finishedTween, sequenceFinished = seq.Update(1)
+	_, finishedTween, sequenceFinished = seq.Update(1)
 	// Now finished because we removed the third tween and then called Sequence.Update()
 	assert.False(t, finishedTween)
 	assert.True(t, sequenceFinished)


### PR DESCRIPTION
Hello again! I've added the ability to fully fiddle with the reverse flag on Sequence... works with both yoyo and non-yoyo, loops and not, in a (hopefully) sensical fashion.

Summary:
- Adds SetReverse();
   - A non-yoyo sequence will loop back to the end from the start
   - A yoyo sequence functions exactly the same, but you just have more control
   - Updated README.md
- A few new tests; still sitting @ 100% coverage
- Ran `go fmt` and `go-critic` against all files
   - Added comments to all the easing functions for better DX
   - Collapsed things like `t = t - 1` to `t--`, and `t = t + 2` to `t += 2`
   - Named return values for the `sequence.Update` function
   
